### PR TITLE
Add Flask loan tracking app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,80 @@
+import os
+import json
+from datetime import date
+from flask import Flask, render_template, request, redirect, url_for, send_from_directory
+
+app = Flask(__name__)
+
+DATA_DIR = os.path.join(app.root_path, 'data')
+os.makedirs(DATA_DIR, exist_ok=True)
+
+def load_loans():
+    loans = []
+    for filename in os.listdir(DATA_DIR):
+        if filename.endswith('.json'):
+            path = os.path.join(DATA_DIR, filename)
+            with open(path) as f:
+                loan = json.load(f)
+            loan_id = os.path.splitext(filename)[0]
+            loan['id'] = loan_id
+            loan['balance'] = loan['principal'] - sum(p['amount'] for p in loan.get('payments', []))
+            loans.append(loan)
+    return loans
+
+
+def load_loan(loan_id):
+    path = os.path.join(DATA_DIR, f"{loan_id}.json")
+    with open(path) as f:
+        loan = json.load(f)
+    loan['id'] = loan_id
+    return loan
+
+
+def save_loan(loan):
+    path = os.path.join(DATA_DIR, f"{loan['id']}.json")
+    data = {k: v for k, v in loan.items() if k != 'id'}
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+@app.route('/')
+def index():
+    loans = load_loans()
+    return render_template('index.html', loans=loans)
+
+
+@app.route('/loan/<loan_id>')
+def loan_details(loan_id):
+    loan = load_loan(loan_id)
+    balance = loan['principal']
+    payment_rows = []
+    for p in loan.get('payments', []):
+        balance -= p['amount']
+        payment_rows.append({
+            'date': p['date'],
+            'amount': p['amount'],
+            'balance': balance
+        })
+    return render_template('loan_details.html', loan=loan, payments=payment_rows, balance=balance)
+
+
+@app.route('/loan/<loan_id>/payment', methods=['GET', 'POST'])
+def add_payment(loan_id):
+    loan = load_loan(loan_id)
+    if request.method == 'POST':
+        amount = float(request.form['amount'])
+        pay_date = request.form['date'] or date.today().isoformat()
+        loan.setdefault('payments', []).append({'date': pay_date, 'amount': amount})
+        save_loan(loan)
+        return redirect(url_for('loan_details', loan_id=loan_id))
+    today = date.today().isoformat()
+    return render_template('add_payment.html', loan=loan, today=today)
+
+
+@app.route('/loan/<loan_id>/download')
+def download_loan(loan_id):
+    return send_from_directory(DATA_DIR, f"{loan_id}.json", as_attachment=True)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/data/alice.json
+++ b/data/alice.json
@@ -1,0 +1,8 @@
+{
+  "child": "Alice",
+  "principal": 1000,
+  "payments": [
+    {"date": "2024-01-01", "amount": 100},
+    {"date": "2024-02-01", "amount": -50}
+  ]
+}

--- a/data/bob.json
+++ b/data/bob.json
@@ -1,0 +1,5 @@
+{
+  "child": "Bob",
+  "principal": 500,
+  "payments": []
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,38 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+}
+
+.container {
+    max-width: 800px;
+    margin: auto;
+    background: #fff;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #eee;
+}
+
+a {
+    color: #0066cc;
+}
+
+a:hover {
+    text-decoration: underline;
+}

--- a/templates/add_payment.html
+++ b/templates/add_payment.html
@@ -1,0 +1,9 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Add Payment for {{ loan.child }}</h1>
+<form method="post">
+  <label>Date: <input type="date" name="date" value="{{ today }}"></label><br>
+  <label>Amount: <input type="number" step="0.01" name="amount" required></label><br>
+  <button type="submit">Save</button>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Loans Summary</h1>
+<table class="loans">
+  <tr><th>Child</th><th>Original Amount</th><th>Balance</th></tr>
+  {% for loan in loans %}
+  <tr>
+    <td><a href="{{ url_for('loan_details', loan_id=loan.id) }}">{{ loan.child }}</a></td>
+    <td>{{ '%.2f'|format(loan.principal) }}</td>
+    <td>{{ '%.2f'|format(loan.balance) }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Bank of Mum</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Loan to {{ loan.child }}</h1>
+<p>Original amount: {{ '%.2f'|format(loan.principal) }}</p>
+<p>Current balance: {{ '%.2f'|format(balance) }}</p>
+<p>
+  <a href="{{ url_for('add_payment', loan_id=loan.id) }}">Add payment</a> |
+  <a href="{{ url_for('download_loan', loan_id=loan.id) }}">Download JSON</a>
+</p>
+<table class="payments">
+  <tr><th>Date</th><th>Payment</th><th>Remaining</th></tr>
+  {% for p in payments %}
+  <tr>
+    <td>{{ p.date }}</td>
+    <td>{{ '%.2f'|format(p.amount) }}</td>
+    <td>{{ '%.2f'|format(p.balance) }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- build Flask app with JSON-backed loan storage
- summary, detail, and payment entry screens with running balance
- downloadable loan JSON and basic styling

## Testing
- `python -m py_compile app.py`
- `pip install flask` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c8174bc6d4832ca40b21d9655934f2