### PR TITLE
Add loan creation with compound interest calculations

### DIFF
--- a/templates/add_loan.html
+++ b/templates/add_loan.html
@@ -1,0 +1,13 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Add Loan</h1>
+<form method="post">
+  <label>Child: <input name="child" required></label><br>
+  <label>Principal: <input name="principal" type="number" step="0.01" required></label><br>
+  <label>Interest rate (% per year): <input name="rate" type="number" step="0.01" required></label><br>
+  <label>Number of months: <input name="months" type="number"></label><br>
+  <label>Payment per month: <input name="payment" type="number" step="0.01"></label><br>
+  <p>Provide either number of months or payment per month to calculate the other.</p>
+  <button type="submit">Add Loan</button>
+</form>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,7 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h1>Loans Summary</h1>
+<p><a href="{{ url_for('add_loan') }}">Add new loan</a></p>
 <table class="loans">
   <tr><th>Child</th><th>Original Amount</th><th>Balance</th></tr>
   {% for loan in loans %}

--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -3,6 +3,9 @@
 <h1>Loan to {{ loan.child }}</h1>
 <p>Original amount: {{ '%.2f'|format(loan.principal) }}</p>
 <p>Current balance: {{ '%.2f'|format(balance) }}</p>
+<p>Interest rate: {{ loan.interest_rate }}%</p>
+<p>Term: {{ loan.months }} months</p>
+<p>Expected payment per month: {{ '%.2f'|format(loan.payment_per_month) }}</p>
 <p>
   <a href="{{ url_for('add_payment', loan_id=loan.id) }}">Add payment</a> |
   <a href="{{ url_for('download_loan', loan_id=loan.id) }}">Download JSON</a>


### PR DESCRIPTION
## Summary
- enable creating new loans from the summary page
- compute monthly payments or term using compound interest
- display interest, term and expected monthly payment for each loan

## Testing
- `python -m py_compile app.py && echo py_compile_succeeded`


------
https://chatgpt.com/codex/tasks/task_e_68c81a557368832c9a5f69345a43dd92