### PR TITLE
Add total expected repayment calculation to loan views

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,6 +38,7 @@ def load_loans():
             loan.setdefault('months', 0)
             loan.setdefault('payment_per_month', 0)
             loan['balance'] = loan['principal'] - sum(p['amount'] for p in loan.get('payments', []))
+            loan['total_expected_repayment'] = loan['payment_per_month'] * loan['months']
             loans.append(loan)
     return loans
 
@@ -50,6 +51,7 @@ def load_loan(loan_id):
     loan.setdefault('interest_rate', 0)
     loan.setdefault('months', 0)
     loan.setdefault('payment_per_month', 0)
+    loan['total_expected_repayment'] = loan['payment_per_month'] * loan['months']
     return loan
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,12 +3,13 @@
 <h1>Loans Summary</h1>
 <p><a href="{{ url_for('add_loan') }}">Add new loan</a></p>
 <table class="loans">
-  <tr><th>Child</th><th>Original Amount</th><th>Balance</th></tr>
+  <tr><th>Child</th><th>Original Amount</th><th>Balance</th><th>Total Expected Repayment</th></tr>
   {% for loan in loans %}
   <tr>
     <td><a href="{{ url_for('loan_details', loan_id=loan.id) }}">{{ loan.child }}</a></td>
     <td>{{ '%.2f'|format(loan.principal) }}</td>
     <td>{{ '%.2f'|format(loan.balance) }}</td>
+    <td>{{ '%.2f'|format(loan.total_expected_repayment) }}</td>
   </tr>
   {% endfor %}
 </table>

--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -6,6 +6,7 @@
 <p>Interest rate: {{ loan.interest_rate }}%</p>
 <p>Term: {{ loan.months }} months</p>
 <p>Expected payment per month: {{ '%.2f'|format(loan.payment_per_month) }}</p>
+<p>Total expected repayment: {{ '%.2f'|format(loan.total_expected_repayment) }}</p>
 <p>
   <a href="{{ url_for('add_payment', loan_id=loan.id) }}">Add payment</a> |
   <a href="{{ url_for('download_loan', loan_id=loan.id) }}">Download JSON</a>


### PR DESCRIPTION
## Summary
- compute total expected repayment for each loan when loading data
- show total expected repayment in loans summary table
- display total expected repayment in individual loan headers

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c81bbd6e80832c8f99beff2f014d57