### PR TITLE
Add payment editing capability

### DIFF
--- a/templates/edit_payment.html
+++ b/templates/edit_payment.html
@@ -1,0 +1,16 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Edit Payment for {{ loan.child }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label for="date" class="form-label">Date</label>
+    <input id="date" type="date" name="date" value="{{ payment.date }}" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label for="amount" class="form-label">Amount</label>
+    <input id="amount" type="number" step="0.01" name="amount" value="{{ '%.2f'|format(payment.amount) }}" required class="form-control">
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}
+

--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -13,7 +13,7 @@
 </div>
 <table class="table table-striped">
   <thead>
-    <tr><th>Date</th><th>Payment</th><th>Remaining</th></tr>
+    <tr><th>Date</th><th>Payment</th><th>Remaining</th><th></th></tr>
   </thead>
   <tbody>
     {% for p in payments %}
@@ -21,6 +21,7 @@
       <td>{{ p.date }}</td>
       <td>{{ '%.2f'|format(p.amount) }}</td>
       <td>{{ '%.2f'|format(p.balance) }}</td>
+      <td><a href="{{ url_for('edit_payment', loan_id=loan.id, payment_index=p.index) }}" class="btn btn-sm btn-secondary">Edit</a></td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- allow editing an existing payment
- show edit links for each payment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c81fad5f78832ca9651844a3132fb6