### PR TITLE
Enable loan editing and payment comments

### DIFF
--- a/templates/add_payment.html
+++ b/templates/add_payment.html
@@ -10,6 +10,10 @@
     <label for="amount" class="form-label">Amount</label>
     <input id="amount" type="number" step="0.01" name="amount" required class="form-control">
   </div>
+  <div class="mb-3">
+    <label for="comment" class="form-label">Comment</label>
+    <input id="comment" name="comment" class="form-control">
+  </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/edit_loan.html
+++ b/templates/edit_loan.html
@@ -1,0 +1,24 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h1>Edit Loan for {{ loan.child }}</h1>
+<form method="post">
+  <div class="mb-3">
+    <label for="principal" class="form-label">Principal</label>
+    <input id="principal" name="principal" type="number" step="0.01" value="{{ loan.principal }}" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label for="rate" class="form-label">Interest rate (% per year)</label>
+    <input id="rate" name="rate" type="number" step="0.01" value="{{ loan.interest_rate }}" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label for="months" class="form-label">Number of months</label>
+    <input id="months" name="months" type="number" value="{{ loan.months or '' }}" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label for="payment" class="form-label">Payment per month</label>
+    <input id="payment" name="payment" type="number" step="0.01" value="{{ loan.payment_per_month or '' }}" class="form-control">
+  </div>
+  <p>Provide either number of months or payment per month to calculate the other.</p>
+  <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/edit_payment.html
+++ b/templates/edit_payment.html
@@ -10,6 +10,10 @@
     <label for="amount" class="form-label">Amount</label>
     <input id="amount" type="number" step="0.01" name="amount" value="{{ '%.2f'|format(payment.amount) }}" required class="form-control">
   </div>
+  <div class="mb-3">
+    <label for="comment" class="form-label">Comment</label>
+    <input id="comment" name="comment" value="{{ payment.comment }}" class="form-control">
+  </div>
   <button type="submit" class="btn btn-primary">Save</button>
 </form>
 {% endblock %}

--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -9,11 +9,12 @@
 <p>Total expected repayment: {{ '%.2f'|format(loan.total_expected_repayment) }}</p>
 <div class="mb-3">
   <a href="{{ url_for('add_payment', loan_id=loan.id) }}" class="btn btn-primary">Add payment</a>
+  <a href="{{ url_for('edit_loan', loan_id=loan.id) }}" class="btn btn-secondary">Edit loan</a>
   <a href="{{ url_for('download_loan', loan_id=loan.id) }}" class="btn btn-secondary">Download JSON</a>
 </div>
 <table class="table table-striped">
   <thead>
-    <tr><th>Date</th><th>Payment</th><th>Remaining</th><th></th></tr>
+    <tr><th>Date</th><th>Payment</th><th>Remaining</th><th>Comment</th><th></th></tr>
   </thead>
   <tbody>
     {% for p in payments %}
@@ -21,6 +22,7 @@
       <td>{{ p.date }}</td>
       <td>{{ '%.2f'|format(p.amount) }}</td>
       <td>{{ '%.2f'|format(p.balance) }}</td>
+      <td>{{ p.comment }}</td>
       <td><a href="{{ url_for('edit_payment', loan_id=loan.id, payment_index=p.index) }}" class="btn btn-sm btn-secondary">Edit</a></td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Add ability to edit existing loans (principal, interest, term, monthly payment)
- Allow comments on payments and display them in loan details

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68c82abf53f8832c84a2fe6fc8a27898