### PR TITLE
Add amortization schedule and final payment summary

### DIFF
--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -1,20 +1,68 @@
 {% extends 'layout.html' %}
 {% block content %}
 <h1>Loan to {{ loan.child }}</h1>
-<p>Original amount: {{ '%.2f'|format(loan.principal) }}</p>
-<p>Current balance: {{ '%.2f'|format(balance) }}</p>
-<p>Interest rate: {{ loan.interest_rate }}%</p>
-<p>Term: {{ loan.months }} months</p>
-<p>Expected payment per month: {{ '%.2f'|format(loan.payment_per_month) }}</p>
-<p>Total expected repayment: {{ '%.2f'|format(loan.total_expected_repayment) }}</p>
+
+<table class="table table-bordered table-sm">
+  <thead>
+    <tr>
+      <th>Original amount</th>
+      <th>Current balance</th>
+      <th>Interest rate</th>
+      <th>Term (months)</th>
+      <th>Expected payment / month</th>
+      <th>Total expected repayment</th>
+      <th>Expected final payment</th>
+      <th>Actual final payment</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{ '%.2f'|format(loan.principal) }}</td>
+      <td>{{ '%.2f'|format(balance) }}</td>
+      <td>{{ '%.2f'|format(loan.interest_rate) }}%</td>
+      <td>{{ loan.months if loan.months else 'N/A' }}</td>
+      <td>{{ '%.2f'|format(loan.payment_per_month) }}</td>
+      <td>{{ '%.2f'|format(loan.total_expected_repayment) }}</td>
+      <td>
+        {% if expected_final_payment %}
+          {{ '%.2f'|format(expected_final_payment.amount) }}
+          {% if expected_final_payment.date %}
+            <div class="text-muted small">{{ expected_final_payment.date }}</div>
+          {% endif %}
+        {% else %}
+          N/A
+        {% endif %}
+      </td>
+      <td>
+        {% if actual_final_payment %}
+          {{ '%.2f'|format(actual_final_payment.amount) }}
+          {% if actual_final_payment.date %}
+            <div class="text-muted small">{{ actual_final_payment.date }}</div>
+          {% endif %}
+        {% else %}
+          N/A
+        {% endif %}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 <div class="mb-3">
   <a href="{{ url_for('add_payment', loan_id=loan.id) }}" class="btn btn-primary">Add payment</a>
   <a href="{{ url_for('edit_loan', loan_id=loan.id) }}" class="btn btn-secondary">Edit loan</a>
   <a href="{{ url_for('download_loan', loan_id=loan.id) }}" class="btn btn-secondary">Download JSON</a>
 </div>
-<table class="table table-striped">
+
+<h2>Payments</h2>
+<table class="table table-striped table-sm">
   <thead>
-    <tr><th>Date</th><th>Payment</th><th>Remaining</th><th>Comment</th><th></th></tr>
+    <tr>
+      <th>Date</th>
+      <th>Payment</th>
+      <th>Remaining</th>
+      <th>Comment</th>
+      <th></th>
+    </tr>
   </thead>
   <tbody>
     {% for p in payments %}
@@ -25,7 +73,67 @@
       <td>{{ p.comment }}</td>
       <td><a href="{{ url_for('edit_payment', loan_id=loan.id, payment_index=p.index) }}" class="btn btn-sm btn-secondary">Edit</a></td>
     </tr>
+    {% else %}
+    <tr>
+      <td colspan="5" class="text-muted">No payments recorded yet.</td>
+    </tr>
     {% endfor %}
   </tbody>
 </table>
+
+<h2>Amortization schedule</h2>
+{% if amortization_schedule %}
+<table class="table table-striped table-sm">
+  <thead>
+    <tr>
+      <th>#</th>
+      <th>Due date</th>
+      <th>Beginning balance</th>
+      <th>Payment</th>
+      <th>Principal</th>
+      <th>Interest</th>
+      <th>Ending balance</th>
+      <th>Expected final payment</th>
+      <th>Actual final payment</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in amortization_schedule %}
+    <tr>
+      <td>{{ row.number }}</td>
+      <td>{{ row.date }}</td>
+      <td>{{ '%.2f'|format(row.begin_balance) }}</td>
+      <td>{{ '%.2f'|format(row.payment) }}</td>
+      <td>{{ '%.2f'|format(row.principal) }}</td>
+      <td>{{ '%.2f'|format(row.interest) }}</td>
+      <td>{{ '%.2f'|format(row.end_balance) }}</td>
+      <td>
+        {% if row.is_final and expected_final_payment %}
+          {{ '%.2f'|format(expected_final_payment.amount) }}
+          {% if expected_final_payment.date %}
+            <div class="text-muted small">{{ expected_final_payment.date }}</div>
+          {% endif %}
+        {% elif row.is_final %}
+          N/A
+        {% endif %}
+      </td>
+      <td>
+        {% if row.is_final %}
+          {% if actual_final_payment %}
+            {{ '%.2f'|format(actual_final_payment.amount) }}
+            {% if actual_final_payment.date %}
+              <div class="text-muted small">{{ actual_final_payment.date }}</div>
+            {% endif %}
+          {% else %}
+            N/A
+          {% endif %}
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="text-muted">No amortization schedule available. Add a loan term and monthly payment to view the expected schedule.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- normalize stored loan values and add amortization schedule generation utilities
- surface actual and expected final payment details in the loan details view
- render an amortization table with monthly interest and final payment comparison in the template

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68c9a998f9a4832cb8cea9fe757a6036