### PR TITLE
Enhance amortization schedule with actual payment forecast

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ from flask import Flask, render_template, request, redirect, url_for, send_from_
 app = Flask(__name__)
 
 DATA_DIR = os.path.join(app.root_path, 'data')
+IGNORED_LOAN_IDS = {"alice", "bob"}
 os.makedirs(DATA_DIR, exist_ok=True)
 
 
@@ -28,11 +29,11 @@ def calculate_months(principal, annual_rate, payment):
 
 def _coerce_months(value):
     if value in (None, ""):
-        return 0
+        return 0.0
     try:
-        return int(value)
+        return float(value)
     except (TypeError, ValueError):
-        return 0
+        return 0.0
 
 
 def _coerce_float(value):
@@ -47,19 +48,39 @@ def _coerce_float(value):
 def load_loans():
     loans = []
     for filename in os.listdir(DATA_DIR):
-        if filename.endswith('.json'):
-            path = os.path.join(DATA_DIR, filename)
-            with open(path) as f:
-                loan = json.load(f)
-            loan_id = os.path.splitext(filename)[0]
-            loan['id'] = loan_id
-            loan['principal'] = _coerce_float(loan.get('principal', 0))
-            loan['interest_rate'] = _coerce_float(loan.get('interest_rate', 0))
-            loan['months'] = _coerce_months(loan.get('months', 0))
-            loan['payment_per_month'] = _coerce_float(loan.get('payment_per_month', 0))
-            loan['balance'] = loan['principal'] - sum(p['amount'] for p in loan.get('payments', []))
-            loan['total_expected_repayment'] = loan['payment_per_month'] * loan['months']
-            loans.append(loan)
+        if not filename.endswith('.json'):
+            continue
+
+        loan_id = os.path.splitext(filename)[0]
+        if loan_id.lower() in IGNORED_LOAN_IDS:
+            continue
+
+        path = os.path.join(DATA_DIR, filename)
+        with open(path) as f:
+            loan = json.load(f)
+
+        loan['id'] = loan_id
+        payments = loan.get('payments') or []
+        loan['payments'] = payments
+
+        principal, annual_rate, months, payment = _resolve_loan_terms(loan)
+        loan['principal'] = principal
+        loan['interest_rate'] = annual_rate
+
+        amortization = generate_amortization_schedule({
+            **loan,
+            'principal': principal,
+            'interest_rate': annual_rate,
+            'months': months,
+            'payment_per_month': payment,
+        })
+
+        loan['months'] = months if months else 0.0
+        loan['payment_per_month'] = payment if payment else 0.0
+        loan['balance'] = round(loan['principal'] - sum(_coerce_float(p.get('amount')) for p in payments), 2)
+        loan['total_expected_repayment'] = round(sum(row['payment'] for row in amortization), 2) if amortization else 0.0
+
+        loans.append(loan)
     return loans
 
 
@@ -68,11 +89,22 @@ def load_loan(loan_id):
     with open(path) as f:
         loan = json.load(f)
     loan['id'] = loan_id
-    loan['principal'] = _coerce_float(loan.get('principal', 0))
-    loan['interest_rate'] = _coerce_float(loan.get('interest_rate', 0))
-    loan['months'] = _coerce_months(loan.get('months', 0))
-    loan['payment_per_month'] = _coerce_float(loan.get('payment_per_month', 0))
-    loan['total_expected_repayment'] = loan['payment_per_month'] * loan['months']
+    loan['payments'] = loan.get('payments') or []
+
+    principal, annual_rate, months, payment = _resolve_loan_terms(loan)
+    loan['principal'] = principal
+    loan['interest_rate'] = annual_rate
+    loan['months'] = months if months else 0.0
+    loan['payment_per_month'] = payment if payment else 0.0
+
+    amortization = generate_amortization_schedule({
+        **loan,
+        'principal': principal,
+        'interest_rate': annual_rate,
+        'months': months,
+        'payment_per_month': payment,
+    })
+    loan['total_expected_repayment'] = round(sum(row['payment'] for row in amortization), 2) if amortization else 0.0
     return loan
 
 
@@ -104,27 +136,66 @@ def _schedule_start_date(loan):
     return today.replace(day=1)
 
 
-def generate_amortization_schedule(loan):
+def _resolve_loan_terms(loan):
     principal = _coerce_float(loan.get('principal', 0))
     annual_rate = _coerce_float(loan.get('interest_rate', 0))
     months = _coerce_months(loan.get('months', 0))
     payment = _coerce_float(loan.get('payment_per_month', 0))
+
+    if principal <= 0:
+        return principal, annual_rate, 0.0, 0.0
+
+    if months <= 0 and payment > 0:
+        months = calculate_months(principal, annual_rate, payment)
+    if payment <= 0 and months > 0:
+        payment = calculate_monthly_payment(principal, annual_rate, months)
+
+    return principal, annual_rate, months, payment
+
+
+def _group_payments_by_period(payments, start_date, total_periods):
+    grouped = {}
+    if not payments:
+        return grouped
+
+    for payment in payments:
+        amount = _coerce_float(payment.get('amount'))
+        if amount == 0:
+            continue
+
+        payment_date = _parse_iso_date(payment.get('date')) or start_date
+        months_delta = (payment_date.year - start_date.year) * 12 + (payment_date.month - start_date.month)
+        period_index = months_delta + 1
+        if period_index < 1:
+            period_index = 1
+        elif period_index > total_periods:
+            period_index = total_periods
+
+        grouped[period_index] = grouped.get(period_index, 0.0) + amount
+
+    return grouped
+
+
+def generate_amortization_schedule(loan):
+    principal, annual_rate, months, payment = _resolve_loan_terms(loan)
 
     if principal <= 0 or months <= 0 or payment <= 0:
         return []
 
     monthly_rate = annual_rate / 12 / 100 if annual_rate else 0
     start_date = _schedule_start_date(loan)
+    total_periods = max(int(math.ceil(months)), 1)
+    payments_by_period = _group_payments_by_period(loan.get('payments', []), start_date, total_periods)
     balance = principal
     schedule = []
 
-    for period in range(1, months + 1):
+    for period in range(1, total_periods + 1):
         begin_balance = balance
         interest = begin_balance * monthly_rate if monthly_rate else 0.0
         payment_amount = payment
 
         # Ensure the final period clears the balance.
-        if period == months:
+        if period == total_periods:
             payment_amount = begin_balance + interest
         elif monthly_rate and payment_amount <= interest:
             # Avoid negative amortization by at least covering the interest.
@@ -145,18 +216,25 @@ def generate_amortization_schedule(loan):
             principal_component = round(payment_amount - interest, 2)
             end_balance = 0.0
 
+        actual_payment = payments_by_period.get(period)
+        if actual_payment is None:
+            actual_payment = payment_amount
+        else:
+            actual_payment = round(actual_payment, 2)
+
         schedule.append({
             'number': period,
             'date': _add_months(start_date, period - 1).isoformat(),
             'begin_balance': round(begin_balance, 2),
             'payment': payment_amount,
+            'actual_payment': actual_payment,
             'interest': interest,
             'principal': principal_component,
             'end_balance': max(end_balance, 0.0),
-            'is_final': period == months
+            'is_final': period == total_periods
         })
 
-        balance = end_balance
+        balance = max(end_balance, 0.0)
 
     return schedule
 
@@ -180,19 +258,29 @@ def add_loan():
         child = request.form['child']
         principal = float(request.form['principal'])
         rate = float(request.form['rate'])
-        months = request.form.get('months')
-        payment = request.form.get('payment')
+        months_value = request.form.get('months')
+        payment_value = request.form.get('payment')
 
-        months = int(months) if months else None
-        payment = float(payment) if payment else None
+        months = float(months_value) if months_value else None
+        payment = float(payment_value) if payment_value else None
+
+        if months is not None and months <= 0:
+            months = None
+        if payment is not None and payment <= 0:
+            payment = None
 
         if months and not payment:
             payment = calculate_monthly_payment(principal, rate, months)
         elif payment and not months:
-            months = math.ceil(calculate_months(principal, rate, payment))
+            months = calculate_months(principal, rate, payment)
         elif not months and not payment:
-            months = 12
+            months = 12.0
             payment = calculate_monthly_payment(principal, rate, months)
+
+        if months is not None:
+            months = round(float(months), 2)
+        if payment is not None:
+            payment = round(float(payment), 2)
 
         loan_id = child.lower().replace(' ', '_')
         loan = {
@@ -215,19 +303,29 @@ def edit_loan(loan_id):
     if request.method == 'POST':
         principal = float(request.form.get('principal', loan['principal']))
         rate = float(request.form.get('rate', 0) or 0)
-        months = request.form.get('months')
-        payment = request.form.get('payment')
+        months_value = request.form.get('months')
+        payment_value = request.form.get('payment')
 
-        months = int(months) if months else None
-        payment = float(payment) if payment else None
+        months = float(months_value) if months_value else None
+        payment = float(payment_value) if payment_value else None
+
+        if months is not None and months <= 0:
+            months = None
+        if payment is not None and payment <= 0:
+            payment = None
 
         if months and not payment:
             payment = calculate_monthly_payment(principal, rate, months)
         elif payment and not months:
-            months = math.ceil(calculate_months(principal, rate, payment))
+            months = calculate_months(principal, rate, payment)
         elif not months and not payment:
-            months = loan.get('months', 0)
-            payment = loan.get('payment_per_month', 0)
+            months = loan.get('months', 0) or 0.0
+            payment = loan.get('payment_per_month', 0) or 0.0
+
+        if months is not None:
+            months = round(float(months), 2)
+        if payment is not None:
+            payment = round(float(payment), 2)
 
         loan.update({
             'principal': principal,
@@ -259,20 +357,17 @@ def loan_details(loan_id):
             'index': idx
         })
 
-    actual_final_payment = None
-    if payments_with_index:
-        final_payment = payments_with_index[-1][1]
-        actual_final_payment = {
-            'amount': _coerce_float(final_payment.get('amount')),
-            'date': final_payment.get('date')
-        }
-
     amortization_schedule = generate_amortization_schedule(loan)
-    expected_final_payment = None
+    expected_payment_info = None
+    actual_payment_info = None
     if amortization_schedule:
         last_row = amortization_schedule[-1]
-        expected_final_payment = {
+        expected_payment_info = {
             'amount': last_row['payment'],
+            'date': last_row['date']
+        }
+        actual_payment_info = {
+            'amount': last_row['actual_payment'],
             'date': last_row['date']
         }
 
@@ -282,8 +377,8 @@ def loan_details(loan_id):
         payments=payment_rows,
         balance=round(balance, 2),
         amortization_schedule=amortization_schedule,
-        actual_final_payment=actual_final_payment,
-        expected_final_payment=expected_final_payment
+        expected_payment_info=expected_payment_info,
+        actual_payment_info=actual_payment_info
     )
 
 

--- a/templates/add_loan.html
+++ b/templates/add_loan.html
@@ -16,7 +16,7 @@
   </div>
   <div class="mb-3">
     <label for="months" class="form-label">Number of months</label>
-    <input id="months" name="months" type="number" class="form-control">
+    <input id="months" name="months" type="number" step="0.01" class="form-control">
   </div>
   <div class="mb-3">
     <label for="payment" class="form-label">Payment per month</label>

--- a/templates/edit_loan.html
+++ b/templates/edit_loan.html
@@ -12,11 +12,11 @@
   </div>
   <div class="mb-3">
     <label for="months" class="form-label">Number of months</label>
-    <input id="months" name="months" type="number" value="{{ loan.months or '' }}" class="form-control">
+    <input id="months" name="months" type="number" step="0.01" value="{{ '%.2f'|format(loan.months) if loan.months else '' }}" class="form-control">
   </div>
   <div class="mb-3">
     <label for="payment" class="form-label">Payment per month</label>
-    <input id="payment" name="payment" type="number" step="0.01" value="{{ loan.payment_per_month or '' }}" class="form-control">
+    <input id="payment" name="payment" type="number" step="0.01" value="{{ '%.2f'|format(loan.payment_per_month) if loan.payment_per_month else '' }}" class="form-control">
   </div>
   <p>Provide either number of months or payment per month to calculate the other.</p>
   <button type="submit" class="btn btn-primary">Save</button>

--- a/templates/loan_details.html
+++ b/templates/loan_details.html
@@ -11,8 +11,8 @@
       <th>Term (months)</th>
       <th>Expected payment / month</th>
       <th>Total expected repayment</th>
-      <th>Expected final payment</th>
-      <th>Actual final payment</th>
+      <th>Expected payment</th>
+      <th>Actual payment</th>
     </tr>
   </thead>
   <tbody>
@@ -20,24 +20,24 @@
       <td>{{ '%.2f'|format(loan.principal) }}</td>
       <td>{{ '%.2f'|format(balance) }}</td>
       <td>{{ '%.2f'|format(loan.interest_rate) }}%</td>
-      <td>{{ loan.months if loan.months else 'N/A' }}</td>
+      <td>{{ '%.2f'|format(loan.months) if loan.months else 'N/A' }}</td>
       <td>{{ '%.2f'|format(loan.payment_per_month) }}</td>
       <td>{{ '%.2f'|format(loan.total_expected_repayment) }}</td>
       <td>
-        {% if expected_final_payment %}
-          {{ '%.2f'|format(expected_final_payment.amount) }}
-          {% if expected_final_payment.date %}
-            <div class="text-muted small">{{ expected_final_payment.date }}</div>
+        {% if expected_payment_info %}
+          {{ '%.2f'|format(expected_payment_info.amount) }}
+          {% if expected_payment_info.date %}
+            <div class="text-muted small">{{ expected_payment_info.date }}</div>
           {% endif %}
         {% else %}
           N/A
         {% endif %}
       </td>
       <td>
-        {% if actual_final_payment %}
-          {{ '%.2f'|format(actual_final_payment.amount) }}
-          {% if actual_final_payment.date %}
-            <div class="text-muted small">{{ actual_final_payment.date }}</div>
+        {% if actual_payment_info %}
+          {{ '%.2f'|format(actual_payment_info.amount) }}
+          {% if actual_payment_info.date %}
+            <div class="text-muted small">{{ actual_payment_info.date }}</div>
           {% endif %}
         {% else %}
           N/A
@@ -89,12 +89,11 @@
       <th>#</th>
       <th>Due date</th>
       <th>Beginning balance</th>
-      <th>Payment</th>
+      <th>Expected payment</th>
+      <th>Actual / forecast payment</th>
       <th>Principal</th>
       <th>Interest</th>
       <th>Ending balance</th>
-      <th>Expected final payment</th>
-      <th>Actual final payment</th>
     </tr>
   </thead>
   <tbody>
@@ -104,31 +103,10 @@
       <td>{{ row.date }}</td>
       <td>{{ '%.2f'|format(row.begin_balance) }}</td>
       <td>{{ '%.2f'|format(row.payment) }}</td>
+      <td>{{ '%.2f'|format(row.actual_payment) }}</td>
       <td>{{ '%.2f'|format(row.principal) }}</td>
       <td>{{ '%.2f'|format(row.interest) }}</td>
       <td>{{ '%.2f'|format(row.end_balance) }}</td>
-      <td>
-        {% if row.is_final and expected_final_payment %}
-          {{ '%.2f'|format(expected_final_payment.amount) }}
-          {% if expected_final_payment.date %}
-            <div class="text-muted small">{{ expected_final_payment.date }}</div>
-          {% endif %}
-        {% elif row.is_final %}
-          N/A
-        {% endif %}
-      </td>
-      <td>
-        {% if row.is_final %}
-          {% if actual_final_payment %}
-            {{ '%.2f'|format(actual_final_payment.amount) }}
-            {% if actual_final_payment.date %}
-              <div class="text-muted small">{{ actual_final_payment.date }}</div>
-            {% endif %}
-          {% else %}
-            N/A
-          {% endif %}
-        {% endif %}
-      </td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- ignore the Alice and Bob datasets while resolving missing term and payment values for each loan
- map recorded payments into the amortization schedule so expected and actual/forecast amounts appear per period
- support fractional month entry and refresh the loan details UI to surface the new payment information

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b5b136b0832ca085004f41da246c